### PR TITLE
refactor: Add `compile-elm` cabal flag ...

### DIFF
--- a/json-spec-elm-servant.cabal
+++ b/json-spec-elm-servant.cabal
@@ -37,7 +37,6 @@ common warnings
     -Wmissing-export-lists
     -Wmissing-import-lists
     -Wredundant-constraints
-    -Wunused-packages
 
 library
   import: dependencies, warnings
@@ -47,17 +46,22 @@ library
   -- other-extensions:    
   hs-source-dirs:      src
   default-language:    Haskell2010
+  ghc-options:
+    -Wunused-packages
   build-depends:
     , bound         >= 2.0.7   && < 2.1
     , http-types    >= 0.12.3  && < 0.13
     , json-spec-elm >= 0.4.0.0 && < 0.5
     , mtl           >= 2.3.1   && < 2.4
 
+flag compile-elm
+  description:
+    Set this flag to run the Elm compilation tests, which requires Elm
+    to be installed on the system.
+  default: False
 
-test-suite test
+test-suite compile-elm
   import: dependencies, warnings
-  main-is: test.hs
-  type: exitcode-stdio-1.0
   hs-source-dirs: test
   default-language: Haskell2010
   other-modules:
@@ -75,4 +79,9 @@ test-suite test
     , time                 >= 1.12.2   && < 1.13
     , unordered-containers >= 0.2.19.1 && < 0.3
     , uuid                 >= 1.3.15   && < 1.4
-
+  if flag(compile-elm)
+    main-is: test.hs
+    type: exitcode-stdio-1.0
+  else
+    main-is: test-pass.hs
+    type: exitcode-stdio-1.0

--- a/json-spec-elm-servant.cabal
+++ b/json-spec-elm-servant.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                json-spec-elm-servant
-version:             0.4.0.0
+version:             0.4.0.1
 synopsis:            Generated elm code for servant APIs.
 description:         Generate Elm encoders, decoders, and API requests
                      for an Servant API, where the shape of the data

--- a/test/test-pass.hs
+++ b/test/test-pass.hs
@@ -1,0 +1,21 @@
+
+{-|
+  A "test" that always passes, so that systems that don't have Elm
+  installed can still run the tests (as, for instance, in some kind of
+  CI workflow that always runs  the tests for all dependencies).
+-}
+module Main (main) where
+
+main :: IO ()
+main =
+  putStrLn $
+    unlines
+      [ ""
+      , ""
+      , "    NB! We are _NOT_ running the tests really because the `compile-elm`"
+      , "    flag is not set. If you are sure that the proper Elm tools are"
+      , "    installed on the system, then you can set the `compile-elm` flag"
+      , "    and real tests will be run"
+      , ""
+      , ""
+      ]


### PR DESCRIPTION
... so that systems that don't have Elm installed can still "run the
tests" successfully.