### PR TITLE
Fix Prelude import: get foldl' from Data.Foldable for GHC 9.8

### DIFF
--- a/json-spec-elm-servant.cabal
+++ b/json-spec-elm-servant.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                json-spec-elm-servant
-version:             0.4.4.2
+version:             0.4.4.3
 synopsis:            Generated elm code for servant APIs.
 description:         Generate Elm encoders, decoders, and API requests
                      for an Servant API, where the shape of the data

--- a/src/Data/JsonSpec/Elm/Servant.hs
+++ b/src/Data/JsonSpec/Elm/Servant.hs
@@ -40,7 +40,7 @@ module Data.JsonSpec.Elm.Servant (
 
 import Bound (Var(B, F), Scope, abstract1, closed, toScope)
 import Control.Monad.Writer (MonadTrans(lift), MonadWriter(tell), execWriter)
-import Data.Foldable (Foldable(fold), traverse_)
+import Data.Foldable (Foldable(fold), foldl', traverse_)
 import Data.HashMap.Strict (HashMap)
 import Data.JsonSpec
   ( HasJsonDecodingSpec(DecodingSpec), HasJsonEncodingSpec(EncodingSpec)
@@ -61,7 +61,7 @@ import Language.Elm.Type (Type)
 import Network.HTTP.Types (Method)
 import Prelude
   ( Applicative(pure), Bool(False, True), Eq((==))
-  , Foldable(foldl', foldr, length), Functor(fmap), Maybe(Just, Nothing)
+  , Foldable(foldr, length), Functor(fmap), Maybe(Just, Nothing)
   , Monad((>>=)), Monoid(mconcat, mempty), Semigroup((<>)), Show(show)
   , Traversable(sequence, traverse), ($), (.), (<$>), IO, Int, String, drop
   , error, init, putStrLn, reverse, unlines


### PR DESCRIPTION
In GHC 9.8 / base 4.19, foldl' was moved from the Foldable class to
Data.Foldable as a standalone function. The explicit Prelude import
Foldable(foldl', ...) therefore failed with 'foldl' is exported but
does not export any children called foldl''.

- Import foldl' from Data.Foldable.
- Remove foldl' from the Prelude Foldable import list.

Prompt: fix build error from refreeze (GHC-10237 foldl' not in Foldable).